### PR TITLE
Fix typo, cought -> caught

### DIFF
--- a/gsecrets/safe_element.py
+++ b/gsecrets/safe_element.py
@@ -745,7 +745,7 @@ class SafeEntry(SafeElement):
                 return self._otp.now()
             except binascii.Error:
                 logging.debug(
-                    "Error cought in OTP token generation (likely invalid "
+                    "Error caught in OTP token generation (likely invalid "
                     "base32 secret)."
                 )
 


### PR DESCRIPTION
Found via `codespell -S po,data`.